### PR TITLE
Remove dependency on deleted file

### DIFF
--- a/efficientdet/dataset/create_coco_tfrecord.py
+++ b/efficientdet/dataset/create_coco_tfrecord.py
@@ -40,7 +40,7 @@ import PIL.Image
 
 from pycocotools import mask
 import tensorflow.compat.v1 as tf
-from dataset import label_map_util
+from dataset.label_map_util import create_category_index
 from dataset import tfrecord_util
 
 
@@ -209,7 +209,7 @@ def _load_object_annotations(object_annotations_file):
     obj_annotations = json.load(fid)
 
   images = obj_annotations['images']
-  category_index = label_map_util.create_category_index(
+  category_index = create_category_index(
       obj_annotations['categories'])
 
   img_to_obj_annotation = collections.defaultdict(list)

--- a/efficientdet/dataset/label_map_util.py
+++ b/efficientdet/dataset/label_map_util.py
@@ -25,7 +25,6 @@ from six.moves import range
 import tensorflow.compat.v1 as tf
 from google.protobuf import text_format
 
-from dataset import string_int_label_map_pb2
 
 
 def _validate_label_map(label_map):


### PR DESCRIPTION
When I was creating tf records with the latest commit 7768c499ede4a732fde022a24d8525b3396b50a4, I got errors of trying to import a file named 'string_int_label_map_pb2', which was deleted.

These few edits are to remove spots in the code where this happens, hope this helps!