### PR TITLE
In infer mode for the parameter of num_classes is invalid, So loading the model causes errors, if my num_classes=2

### DIFF
--- a/efficientdet/inference.py
+++ b/efficientdet/inference.py
@@ -429,7 +429,7 @@ class InferenceDriver(object):
 
   """
 
-  def __init__(self, model_name: Text, ckpt_path: Text, image_size: int = None,
+  def __init__(self, model_name: Text, ckpt_path: Text, image_size: int = None, num_classes: int = None,
                label_id_mapping: Dict[int, Text] = None):
     """Initialize the inference driver.
 
@@ -449,7 +449,8 @@ class InferenceDriver(object):
     self.params.update(dict(is_training_bn=False, use_bfloat16=False))
     if image_size:
       self.params.update(dict(image_size=image_size))
-
+    if num_classes:
+      self.params.update(dict(num_classes=num_classes))
   def inference(self,
                 image_path_pattern: Text,
                 output_dir: Text,

--- a/efficientdet/model_inspect.py
+++ b/efficientdet/model_inspect.py
@@ -210,7 +210,7 @@ class ModelInspector(object):
 
   def inference_single_image(self, image_image_path, output_dir, **kwargs):
     driver = inference.InferenceDriver(self.model_name, self.ckpt_path,
-                                       self.image_size)
+                                       self.image_size, self.num_classes)
     driver.inference(image_image_path, output_dir, **kwargs)
 
   def freeze_model(self) -> Tuple[Text, Text]:


### PR DESCRIPTION
hello, @mingxingtan, my custom dataset have 2 classes, i convert the dataset to coco format; The training process is normal, but predict some images, I looked at the picture results, to my surprise, only one category can be predicted，another category of object is missing in predicting images. I also asked my questions #81 .Later, it was found that there was a problem in the conversion of the script I wrote. The category should start from 1, but I started from 0, which led to this problem, finally, I solved the problem. Today, I tested my training model and used your tutorial, but found that the modification of num classes is invalid, and an error will be reported when loading the model. I debugged your code and found that the num classes parameter of the command line did not modify the num classes in config, so I proposed my request.