### PR TITLE
optimize batch inference

### DIFF
--- a/efficientdet/dataloader.py
+++ b/efficientdet/dataloader.py
@@ -298,7 +298,6 @@ class InputReader(object):
 
         source_id = tf.where(tf.equal(source_id, tf.constant('')), '-1',
                              source_id)
-        source_id = tf.string_to_number(source_id)
 
         # Pad groundtruth data for evaluation.
         image_scale = input_processor.image_scale_to_original


### PR DESCRIPTION
The previous implementation doesn't support batch images to get different results.
Since ```tf.stack``` only supports stack results with the same shapes.
Remove ```tf.stack``` fix the bug.
Use ```tf.image.non_max_suppression``` for better compatibility.
I removed image_id which breaks coco_metric.
Is image_id required?