### PR TITLE
Accept custom hyper-parameter files 

### DIFF
--- a/efficientdet/README.md
+++ b/efficientdet/README.md
@@ -117,13 +117,13 @@ latency and throughput are:
     # Step 1: export saved model.
     !python model_inspect.py --runmode=saved_model \
       --model_name=efficientdet-d0 --ckpt_path=efficientdet-d0 \
-      --input_image_size=1920x1280 \
+      --hparams="image_size=1920x1280" \
       --saved_model_dir=/tmp/saved_model
 
     # Step 2: do inference with saved model.
     !python model_inspect.py --runmode=saved_model_infer \
       --model_name=efficientdet-d0   --ckpt_path=efficientdet-d0 \
-      --input_image_size=1920x1280  \
+      --hparams="image_size=1920x1280"  \
       --saved_model_dir=/tmp/saved_model  \
       --input_image=img.png --output_image_dir=/tmp/
     # you can visualize the output /tmp/0.jpg
@@ -135,7 +135,7 @@ Alternatively, if you want to do inference using frozen graph instead of saved m
     # Step 2: do inference with frozen graph.
     !python model_inspect.py --runmode=saved_model_infer \
       --model_name=efficientdet-d0   --ckpt_path=efficientdet-d0 \
-      --input_image_size=1920x1280  \
+      --hparams="image_size=1920x1280"  \
       --saved_model_dir=/tmp/saved_model/efficientdet-d0_frozen.pb  \
       --input_image=img.png --output_image_dir=/tmp/
 
@@ -143,7 +143,7 @@ Lastly, if you only have one image and just want to run a quick test, you can al
 
     # Run inference for a single image.
     !python model_inspect.py --runmode=infer --model_name=$MODEL \
-      --input_image_size=1920x1280 --max_boxes_to_draw=100   --min_score_thresh=0.4 \
+      --hparams="image_size=1920x1280"  --max_boxes_to_draw=100   --min_score_thresh=0.4 \
       --ckpt_path=$CKPT_PATH --input_image=img.png --output_image_dir=/tmp
     # you can visualize the output /tmp/0.jpg
 
@@ -250,6 +250,13 @@ You can also run eval on test-dev set with the following command:
         --use_tpu=False
 
 ## 8. Finetune on PASCAL VOC 2012 with detector COCO ckpt.
+Create a config file for the PASCAL VOC dataset called voc_config.py and put this in it.
+
+      use_bfloat16=False
+      num_classes=20
+      moving_average_decay=0
+
+
     # Download efficientdet coco checkpoint.
     !wget https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-d0.tar.gz
     !tar xf efficientdet-d0.tar.gz
@@ -265,7 +272,7 @@ You can also run eval on test-dev set with the following command:
         --train_batch_size=8 \
         --eval_batch_size=8 --eval_samples=1024 \
         --num_examples_per_epoch=5717 --num_epochs=1  \
-        --hparams="use_bfloat16=false,num_classes=20,moving_average_decay=0" \
+        --hparams=voc_config \
         --use_tpu=False
 
 ## 9. Training EfficientDets on TPUs.

--- a/efficientdet/README.md
+++ b/efficientdet/README.md
@@ -256,12 +256,13 @@ Create a config file for the PASCAL VOC dataset called voc_config.py and put thi
       num_classes=20
       moving_average_decay=0
 
+Download efficientdet coco checkpoint.
 
-    # Download efficientdet coco checkpoint.
     !wget https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-d0.tar.gz
     !tar xf efficientdet-d0.tar.gz
 
-    # Finetune needs to use --ckpt rather than --backbone_ckpt.
+Finetune needs to use --ckpt rather than --backbone_ckpt.
+
     !python main.py --mode=train_and_eval \
         --training_file_pattern=tfrecord/pascal*.tfrecord \
         --validation_file_pattern=tfrecord/pascal*.tfrecord \

--- a/efficientdet/efficientdet_arch.py
+++ b/efficientdet/efficientdet_arch.py
@@ -673,6 +673,8 @@ def efficientdet(features, model_name=None, config=None, **kwargs):
 
   if not config:
     config = hparams_config.get_efficientdet_config(model_name)
+  elif isinstance(config, dict):
+    config = hparams_config.Config(config) # wrap dict in Config object
 
   if kwargs:
     config.override(kwargs)

--- a/efficientdet/hparams_config.py
+++ b/efficientdet/hparams_config.py
@@ -65,13 +65,13 @@ class Config(object):
       return
 
     for k, v in six.iteritems(config_dict):
-      if k not in self.__dict__.keys():
+      if k not in self.__dict__:
         if allow_new_keys:
           self.__setattr__(k, v)
         else:
           raise KeyError('Key `{}` does not exist for overriding. '.format(k))
       else:
-        if isinstance(v, dict):
+        if isinstance(self.__dict__[k], dict):
           self.__dict__[k]._update(v, allow_new_keys)
         else:
           self.__dict__[k] = copy.deepcopy(v)
@@ -160,7 +160,7 @@ def default_detection_configs():
 
   # input preprocessing parameters
   h.image_size = 640   # An integer or a string WxH such as 640x320.
-  h.batch_size=1
+  h.batch_size = 1
   h.input_rand_hflip = True
   h.train_scale_min = 0.1
   h.train_scale_max = 2.0
@@ -169,6 +169,7 @@ def default_detection_configs():
   # dataset specific parameters
   h.num_classes = 90
   h.skip_crowd_during_training = True
+  h.label_id_mapping = None
 
   # model architecture
   h.min_level = 3

--- a/efficientdet/hparams_config.py
+++ b/efficientdet/hparams_config.py
@@ -68,7 +68,7 @@ class Config(object):
       if k not in self.__dict__:
         if allow_new_keys:
           self.__setattr__(k, v)
-        else:
+        else:   
           raise KeyError('Key `{}` does not exist for overriding. '.format(k))
       else:
         if isinstance(self.__dict__[k], dict):
@@ -102,22 +102,17 @@ class Config(object):
 
   def parse_from_module(self, module_name: str) -> dict:
     """
-    Treat config_str as a module name with key=value pairs defined
-    as attributes and return dict.
+    Import config from module_name containing key=value pairs.
     """
     config_dict = {}
+    module = __import__(module_name)
 
-    try:
-      module = __import__(module_name)
-    except ModuleNotFoundError:
-      raise ValueError("%s.py is not an importable python module"
-                        % module_name)
     for attr in dir(module):
-      if not attr.startswith("__")  :
+      # skip built-ins and private attributes
+      if not attr.startswith("_"):
         config_dict[attr] = getattr(module, attr)
 
     return config_dict
-
 
   def parse_from_str(self, config_str):
     """parse from a string in format 'x=a,y=2' and return the dict."""
@@ -237,16 +232,6 @@ def default_detection_configs():
 
 
 efficientdet_model_param_dict = {
-        'efficientdet-m2':
-        dict(
-            name='efficientdet-m2',
-            backbone_name='efficientnet-lite0',
-            image_size=256,
-            fpn_num_filters=36,
-            fpn_cell_repeats=2,
-            box_class_repeats=2,
-        ),
-
     'efficientdet-d0':
         dict(
             name='efficientdet-d0',

--- a/efficientdet/hparams_config.py
+++ b/efficientdet/hparams_config.py
@@ -187,6 +187,7 @@ def default_detection_configs():
   h.clip_gradients_norm = 10.0
   h.num_epochs = 300
   h.data_format = 'channels_last'
+  h.enable_ema = True
 
   # classification loss
   h.alpha = 0.25

--- a/efficientdet/hparams_config.py
+++ b/efficientdet/hparams_config.py
@@ -68,7 +68,7 @@ class Config(object):
       if k not in self.__dict__:
         if allow_new_keys:
           self.__setattr__(k, v)
-        else:   
+        else:
           raise KeyError('Key `{}` does not exist for overriding. '.format(k))
       else:
         if isinstance(self.__dict__[k], dict):
@@ -89,7 +89,9 @@ class Config(object):
   def override(self, config_dict_or_str):
     """Update members while disallowing new keys."""
     if isinstance(config_dict_or_str, str):
-      if "=" in config_dict_or_str:
+      if not config_dict_or_str:
+        return
+      elif "=" in config_dict_or_str:
         config_dict = self.parse_from_str(config_dict_or_str)
       else:
         config_dict = self.parse_from_module(config_dict_or_str)

--- a/efficientdet/hparams_config.py
+++ b/efficientdet/hparams_config.py
@@ -157,7 +157,6 @@ def default_detection_configs():
 
   # input preprocessing parameters
   h.image_size = 640   # An integer or a string WxH such as 640x320.
-  h.batch_size = 1
   h.input_rand_hflip = True
   h.train_scale_min = 0.1
   h.train_scale_max = 2.0

--- a/efficientdet/inference.py
+++ b/efficientdet/inference.py
@@ -344,7 +344,6 @@ class ServingDriver(object):
                model_name: Text,
                ckpt_path: Text,
                params: dict,
-               enable_ema: bool = True,
                use_xla: bool = False,
                min_score_thresh: float = None,
                max_boxes_to_draw: float = None,
@@ -355,7 +354,6 @@ class ServingDriver(object):
     Args:
       model_name: target model name, such as efficientdet-d0.
       ckpt_path: checkpoint path, such as /tmp/efficientdet-d0/.
-      enable_ema: whether to enable moving average.
       use_xla: Whether run with xla optimization.
       min_score_thresh: minimal score threshold for filtering predictions.
       max_boxes_to_draw: the maximum number of boxes per image.
@@ -374,7 +372,6 @@ class ServingDriver(object):
     self.signitures = None
     self.sess = None
     self.disable_pyfun = True
-    self.enable_ema = enable_ema
     self.use_xla = use_xla
 
     self.min_score_thresh = min_score_thresh or anchors.MIN_SCORE_THRESH
@@ -435,7 +432,7 @@ class ServingDriver(object):
       restore_ckpt(
           self.sess,
           self.ckpt_path,
-          enable_ema=self.enable_ema,
+          enable_ema=self.params['enable_ema'],
           export_ckpt=None)
 
     self.signitures = {
@@ -617,14 +614,12 @@ class InferenceDriver(object):
                model_name: Text,
                ckpt_path: Text,
                params: dict,
-               enable_ema: bool = True,
                **kwargs):
     """Initialize the inference driver.
 
     Args:
       model_name: target model name, such as efficientdet-d0.
       ckpt_path: checkpoint path, such as /tmp/efficientdet-d0/.
-      enable_ema: whether to enable moving average.
     """
     self.model_name = model_name
     self.ckpt_path = ckpt_path
@@ -635,7 +630,6 @@ class InferenceDriver(object):
     self.params.update(kwargs)
 
     self.disable_pyfun = True
-    self.enable_ema = enable_ema
 
   def inference(self, image_path_pattern: Text, output_dir: Text, **kwargs):
     """Read and preprocess input images.
@@ -661,7 +655,7 @@ class InferenceDriver(object):
       class_outputs, box_outputs = build_model(self.model_name, images,
                                                **self.params)
       restore_ckpt(
-          sess, self.ckpt_path, enable_ema=self.enable_ema, export_ckpt=None)
+          sess, self.ckpt_path, enable_ema=self.params['enable_ema'], export_ckpt=None)
       # for postprocessing.
       params.update(
           dict(batch_size=len(raw_images), disable_pyfun=self.disable_pyfun))

--- a/efficientdet/main.py
+++ b/efficientdet/main.py
@@ -66,7 +66,8 @@ flags.DEFINE_string('ckpt', None,
                     'Start training from this EfficientDet checkpoint.')
 
 flags.DEFINE_string('hparams', '',
-                    'Comma separated k=v pairs of hyperparameters.')
+                    'Comma separated k=v pairs of hyperparameters or'
+                    ' a module containing attributes to use as hyperparameters.')
 flags.DEFINE_integer(
     'num_cores', default=8, help='Number of TPU cores for training')
 flags.DEFINE_bool('use_spatial_partition', False, 'Use spatial partition.')

--- a/efficientdet/model_inspect.py
+++ b/efficientdet/model_inspect.py
@@ -168,9 +168,9 @@ class ModelInspector(object):
     driver = inference.ServingDriver(
         self.model_name,
         self.ckpt_path,
+        self.model_params,
         enable_ema=self.enable_ema,
         use_xla=self.use_xla,
-        params=self.model_params,
         **kwargs)
     driver.build()
     driver.export(self.saved_model_dir)
@@ -180,7 +180,7 @@ class ModelInspector(object):
     driver = inference.ServingDriver(
         self.model_name,
         self.ckpt_path,
-        params=self.model_params,
+        self.model_params,
         enable_ema=self.enable_ema,
         use_xla=self.use_xla,
         **kwargs)
@@ -206,6 +206,7 @@ class ModelInspector(object):
     driver = inference.ServingDriver(
         self.model_name,
         self.ckpt_path,
+        self.model_params,
         enable_ema=self.enable_ema,
         use_xla=self.use_xla,
         **kwargs)
@@ -224,7 +225,7 @@ class ModelInspector(object):
     driver = inference.ServingDriver(
         self.model_name,
         self.ckpt_path,
-        params=self.model_params,
+        self.model_params,
         enable_ema=self.enable_ema,
         use_xla=self.use_xla)
     driver.load(self.saved_model_dir)


### PR DESCRIPTION
When developing custom models, I had to edit the `hparams_config.py` file because I was changing too many parameters to use the `--hparams` option. The hyper-parameters also need to stay the same between training and inference, and `inspect_model.py` did not take the `--hparams` option. This made pulling updates hard because of merge conflicts in the config file.

I made `model_inspect.py` accept the `--hparams` option, and modified `--hparams` to take either a python module or key-value pairs.

Example:

```
python model_inspect.py --model_name efficientdet-d0  \
  --runmode=infer --ckpt_path=ckpt \
  --hparams=config  \
  --input_image=test.jpg  --output_image_dir=/tmp
```

Where `config.py` is a file containing the hyper-parameters for the scaled-down model I want to use to recognize persons and bicycles.

```
backbone_name='efficientnet-lite0'
image_size=256
fpn_num_filters=36
fpn_cell_repeats=2
box_class_repeats=2
image_size=256
num_classes=20

label_id_mapping={
  15: "person",
  2: "bicycle"
}
```

This approach makes keeping track of custom hyper-parameters easier and seems like it could benefit others.

I'd be happy to make any changes requested to merge this in. If this does not fit within the design goals of this project, feel free to just close this PR.