### PR TITLE
Add Yolo4 tricks to improve performance [WIP]

### DIFF
--- a/efficientdet/anchors.py
+++ b/efficientdet/anchors.py
@@ -46,6 +46,8 @@ MAX_DETECTIONS_PER_IMAGE = 100
 # The minimal score threshold.
 MIN_SCORE_THRESH = 0.4
 
+# A small number to stabilize division
+EPSILON = 1e-16
 
 def sigmoid(x):
   """Sigmoid function for use with Numpy for CPU evaluation."""
@@ -224,7 +226,7 @@ def softnms(dets, nms_configs):
   iou_thresh = nms_configs.get('iou_thresh', 0.3)
   score_thresh = nms_configs.get('score_thresh', 0.001)
 
-  if method not in ('linear', 'gaussian', 'hard'):
+  if method not in ('linear', 'gaussian', 'hard', 'diou'):
     raise ValueError(
         'NMS method must be linear/gaussian/hard, got: {}'.format(method))
 

--- a/efficientdet/det_model_fn.py
+++ b/efficientdet/det_model_fn.py
@@ -165,7 +165,7 @@ def focal_loss(y_pred, y_true, alpha, gamma, label_smoothing, normalizer):
 
     # Get the cross_entropy for each entry
     ce = tf.keras.losses.categorical_crossentropy(
-        y_true, y_pred, from_logints=True, label_smoothing=label_smoothing)
+        y_true, y_pred, from_logits=True, label_smoothing=label_smoothing)
 
     pred_prob = tf.sigmoid(y_pred)
 

--- a/efficientdet/det_model_fn.py
+++ b/efficientdet/det_model_fn.py
@@ -157,7 +157,7 @@ def focal_loss(y_pred, y_true, alpha, gamma, label_smoothing, normalizer):
       and (1-alpha) to the loss from negative examples.
     gamma: A float32 scalar modulating loss from hard and easy examples.
     label_smoothing: Float in [0, 1]. If > `0` then smooth the labels.
-    normalzier: Divide loss by this value
+    normalizer: Divide loss by this value
   """
   with tf.name_scope('focal_loss'):
     alpha = tf.convert_to_tensor(alpha, dtype=y_pred.dtype)

--- a/efficientdet/hparams_config.py
+++ b/efficientdet/hparams_config.py
@@ -211,14 +211,18 @@ def default_detection_configs():
   h.data_format = 'channels_last'
 
   # classification loss
+  h.label_smoothing = 0.0 # 0.1 is a good default
+  # Behold the focal loss parameters
   h.alpha = 0.25
   h.gamma = 1.5
-  h.label_smoothing = 0.0 # 0.1 is a good default
+
   # localization loss
-  h.delta = 0.1
+  h.delta = 0.1 # This is the regularization parameter of huber loss
+  # total loss = box_loss * box_loss_weight + iou_loss * iou_loss_weight
   h.box_loss_weight = 50.0
   h.iou_loss_type = None
   h.iou_loss_weight = 1.0
+
   # regularization l2 loss.
   h.weight_decay = 4e-5
   # use horovod for multi-gpu training. If None, use TF default.
@@ -235,6 +239,13 @@ def default_detection_configs():
   h.conv_bn_act_pattern = False
   h.use_native_resize_op = True
   h.pooling_type = None
+
+  # post processing
+  # Method used by nms to compare bounding boxes.
+  # diou may be more accurate but only has a numpy
+  # implementatipn for now
+  h.nms = "iou" # iou or diou.
+  h.iou_threshold = 0.5
 
   # version.
   h.fpn_name = None

--- a/efficientdet/hparams_config.py
+++ b/efficientdet/hparams_config.py
@@ -213,6 +213,7 @@ def default_detection_configs():
   # classification loss
   h.alpha = 0.25
   h.gamma = 1.5
+  h.label_smoothing = 0.0 # 0.1 is a good default
   # localization loss
   h.delta = 0.1
   h.box_loss_weight = 50.0

--- a/efficientdet/inference.py
+++ b/efficientdet/inference.py
@@ -327,7 +327,10 @@ def det_post_process(params: Dict[Any, Any], cls_outputs: Dict[int, tf.Tensor],
         image_size=params['image_size'],
         min_score_thresh=min_score_thresh,
         max_boxes_to_draw=max_boxes_to_draw,
-        disable_pyfun=params.get('disable_pyfun'))
+        disable_pyfun=params.get('disable_pyfun'),
+        iou_threshold=params["iou_threshold"],
+        nms=params["nms"],
+      )
     if params['batch_size'] > 1:
       # pad to fixed length if batch size > 1.
       padding_size = max_boxes_to_draw - tf.shape(detections)[0]

--- a/efficientdet/utils.py
+++ b/efficientdet/utils.py
@@ -38,6 +38,8 @@ def activation_fn(features: tf.Tensor, act_type: Text):
     return tf.nn.swish(features)
   elif act_type == 'swish_native':
     return features * tf.sigmoid(features)
+  elif act_type == 'hard_swish':
+    return features * tf.nn.relu6(features + 3) / 6
   elif act_type == 'relu':
     return tf.nn.relu(features)
   elif act_type == 'relu6':

--- a/efficientdet/utils.py
+++ b/efficientdet/utils.py
@@ -42,6 +42,8 @@ def activation_fn(features: tf.Tensor, act_type: Text):
     return tf.nn.relu(features)
   elif act_type == 'relu6':
     return tf.nn.relu6(features)
+  elif act_type == 'mish':
+    return features * tf.math.tanh(tf.math.softplus(features))
   else:
     raise ValueError('Unsupported act_type {}'.format(act_type))
 

--- a/efficientdet/utils.py
+++ b/efficientdet/utils.py
@@ -38,7 +38,7 @@ def activation_fn(features: tf.Tensor, act_type: Text):
     return tf.nn.swish(features)
   elif act_type == 'swish_native':
     return features * tf.sigmoid(features)
-  elif act_type == 'hard_swish':
+  elif act_type == 'hswish':
     return features * tf.nn.relu6(features + 3) / 6
   elif act_type == 'relu':
     return tf.nn.relu(features)

--- a/efficientdet/utils_test.py
+++ b/efficientdet/utils_test.py
@@ -128,7 +128,7 @@ class ActivationTest(tf.test.TestCase):
 
   def test_hard_swish(self):
     features = tf.constant([.5, 10])
-    result = utils.activation_fn(features, "hard_swish")
+    result = utils.activation_fn(features, "hswish")
     self.assertAllClose(result, [0.2916666666666667, 10.0])
 
   def test_relu(self):

--- a/efficientdet/utils_test.py
+++ b/efficientdet/utils_test.py
@@ -114,6 +114,33 @@ class UtilsTest(tf.test.TestCase):
     self.assertIs(out.dtype, tf.float16)  # output should be float16.
 
 
+class ActivationTest(tf.test.TestCase):
+
+  def test_swish(self):
+    features = tf.constant([.5, 10])
+
+    result = utils.activation_fn(features, "swish")
+    expected = features * tf.sigmoid(features)
+    self.assertAllClose(result, expected)
+
+    result = utils.activation_fn(features, "swish_native")
+    self.assertAllClose(result, expected)
+
+  def test_relu(self):
+    features = tf.constant([.5, 10])
+    result = utils.activation_fn(features, "relu")
+    self.assertAllClose(result, [0.5, 10])
+
+  def test_relu6(self):
+    features = tf.constant([.5, 10])
+    result = utils.activation_fn(features, "relu6")
+    self.assertAllClose(result, [0.5, 6])
+
+  def test_mish(self):
+    features = tf.constant([.5, 10])
+    result = utils.activation_fn(features, "mish")
+    self.assertAllClose(result, [0.37524524, 10.0])
+
 if __name__ == '__main__':
   logging.set_verbosity(logging.WARNING)
   tf.disable_eager_execution()

--- a/efficientdet/utils_test.py
+++ b/efficientdet/utils_test.py
@@ -126,6 +126,11 @@ class ActivationTest(tf.test.TestCase):
     result = utils.activation_fn(features, "swish_native")
     self.assertAllClose(result, expected)
 
+  def test_hard_swish(self):
+    features = tf.constant([.5, 10])
+    result = utils.activation_fn(features, "hard_swish")
+    self.assertAllClose(result, [0.2916666666666667, 10.0])
+
   def test_relu(self):
     features = tf.constant([.5, 10])
     result = utils.activation_fn(features, "relu")


### PR DESCRIPTION
Hi @mingxingtan

I'd like to implement some of the cheap tricks used in the  [yolo4  paper](https://arxiv.org/pdf/2004.10934.pdf) to increase EfficientDet's performance.

Here are some of the things I'm thinking of implementing and testing:

- [x] Class label smoothing
- [x] Mish activation
- [x] Hard swish activation from mobilenetv3. I want to see if it improves inference time.
- [x] DIOU NMS
- CIOU loss

Maybe you've thought of this before. Do you have any insights/suggestions concerning this line of work? Have any of these been tried for this project?

Thanks!