### PR TITLE
fix importing distributions when tfp not available

### DIFF
--- a/efficientdet/aug/autoaugment.py
+++ b/efficientdet/aug/autoaugment.py
@@ -39,9 +39,9 @@ except ImportError:
 
 try:
   # tensorflow_probability are recommended, but they only support tf2.
-  import tensorflow_probability as tfp  # pylint: disable=g-import-not-at-top
+  from tensorflow_probability import distributions  # pylint: disable=g-import-not-at-top
 except ImportError:
-  import tensorflow.distributions as tfp  # pylint: disable=g-import-not-at-top
+  import tensorflow.distributions as distributions  # pylint: disable=g-import-not-at-top
 
 # This signifies the max integer that the controller RNN could predict for the
 # augmentation scheme.
@@ -1565,8 +1565,8 @@ def select_and_apply_random_policy_augmix(policies,
   policy_to_select = tf.random_uniform([], maxval=len(policies), dtype=tf.int32)
   # Note that using tf.case instead of tf.conds would result in significantly
   # larger graphs and would even break export for some larger policies.
-  ws = tfp.distributions.Dirichlet([alpha] * mixture_width).sample()
-  m = tfp.distributions.Beta(alpha, alpha).sample()
+  ws = distributions.Dirichlet([alpha] * mixture_width).sample()
+  m = distributions.Beta(alpha, alpha).sample()
   mix = tf.zeros_like(image, dtype=tf.float32)
   for j in range(mixture_width):
     aug_image = image


### PR DESCRIPTION
Summary:
Updated imports to fix accessing `Beta` and `Dirichlet` distributions when `tensorflow_probability` is not available for import.

Issue:
If `tensorflow_probability` is not available for import, `tensorflow.distributions` is mapped to `tfp` instead.  `tfp` is used for `tfp.distributions.Beta` and `tfp.distributions.Dirichlet` which provide the following error when called:
```
AttributeError: module 'tensorflow.distributions' has no attribute 'distributions'
```