### PR TITLE
fix getting dim for dynamic batch size, use batch size value

### DIFF
--- a/efficientdet/inference.py
+++ b/efficientdet/inference.py
@@ -315,12 +315,12 @@ def det_post_process(params: Dict[Any, Any], cls_outputs: Dict[int, tf.Tensor],
     # Use combined version for dynamic batch size.
     nms_boxes, nms_scores, nms_classes, _ = postprocess.postprocess_combined(
         params, cls_outputs, box_outputs, scales)
-    batch_size = tf.shape(list(cls_outputs.values())[0])[0]
+    batch_size = list(cls_outputs.values())[0].shape[0]
   else:
     nms_boxes, nms_scores, nms_classes, _ = postprocess.postprocess_global(
         params, cls_outputs, box_outputs, scales)
 
-  img_ids = tf.range(0, batch_size, dtype=nms_scores.dtype)
+  img_ids = tf.range(0, batch_size.value, dtype=nms_scores.dtype)
   detections = [
       img_ids * tf.ones_like(nms_scores),
       nms_boxes[:, :, 0],


### PR DESCRIPTION
Current logic sets `img_ids` using `batch_size` of type Dimension or Tensor instead of int.

Changed how `batch_size` is set in dynamic case so that both are of type Dimension, and changed how `img_ids` is set to use `batch_size.value` to fix the following errors:

```
Traceback (most recent call last):
  File "model_inspect.py", line 489, in <module>
    app.run(main)
  File "/opt/conda/lib/python3.7/site-packages/absl/app.py", line 299, in run
    _run_main(main, args)
  File "/opt/conda/lib/python3.7/site-packages/absl/app.py", line 250, in _run_main
    sys.exit(main(argv))
  File "model_inspect.py", line 483, in main
    trace_filename=FLAGS.trace_filename)
  File "model_inspect.py", line 436, in run_model
    self.export_saved_model(**config_dict)
  File "model_inspect.py", line 146, in export_saved_model
    driver.build()
  File "/home/jovyan/work/efficientdet/inference.py", line 554, in build
    detections = det_post_process(params, class_outputs, box_outputs, scales)
  File "/home/jovyan/work/efficientdet/inference.py", line 323, in det_post_process
    img_ids = tf.range(0, batch_size, dtype=nms_scores.dtype)
  File "/opt/conda/lib/python3.7/site-packages/tensorflow_core/python/ops/math_ops.py", line 1411, in range
    limit = ops.convert_to_tensor(limit, dtype=dtype, name="limit")
  File "/opt/conda/lib/python3.7/site-packages/tensorflow_core/python/framework/ops.py", line 1184, in convert_to_tensor
    return convert_to_tensor_v2(value, dtype, preferred_dtype, name)
  File "/opt/conda/lib/python3.7/site-packages/tensorflow_core/python/framework/ops.py", line 1242, in convert_to_tensor_v2
    as_ref=False)
  File "/opt/conda/lib/python3.7/site-packages/tensorflow_core/python/framework/ops.py", line 1297, in internal_convert_to_tensor
    ret = conversion_func(value, dtype=dtype, name=name, as_ref=as_ref)
  File "/opt/conda/lib/python3.7/site-packages/tensorflow_core/python/framework/constant_op.py", line 338, in _dimension_tensor_conversion_function
    raise TypeError("Cannot convert a TensorShape to dtype: %s" % dtype)
TypeError: Cannot convert a TensorShape to dtype: <dtype: 'float32'>
```

```
Traceback (most recent call last):
  File "model_inspect.py", line 489, in <module>
    app.run(main)
  File "/opt/conda/lib/python3.7/site-packages/absl/app.py", line 299, in run
    _run_main(main, args)
  File "/opt/conda/lib/python3.7/site-packages/absl/app.py", line 250, in _run_main
    sys.exit(main(argv))
  File "model_inspect.py", line 483, in main
    trace_filename=FLAGS.trace_filename)
  File "model_inspect.py", line 436, in run_model
    self.export_saved_model(**config_dict)
  File "model_inspect.py", line 146, in export_saved_model
    driver.build()
  File "/home/jovyan/work/efficientdet/inference.py", line 554, in build
    detections = det_post_process(params, class_outputs, box_outputs, scales)
  File "/home/jovyan/work/efficientdet/inference.py", line 323, in det_post_process
    img_ids = tf.range(0, batch_size, dtype=nms_scores.dtype)
  File "/opt/conda/lib/python3.7/site-packages/tensorflow_core/python/ops/math_ops.py", line 1411, in range
    limit = ops.convert_to_tensor(limit, dtype=dtype, name="limit")
  File "/opt/conda/lib/python3.7/site-packages/tensorflow_core/python/framework/ops.py", line 1184, in convert_to_tensor
    return convert_to_tensor_v2(value, dtype, preferred_dtype, name)
  File "/opt/conda/lib/python3.7/site-packages/tensorflow_core/python/framework/ops.py", line 1242, in convert_to_tensor_v2
    as_ref=False)
  File "/opt/conda/lib/python3.7/site-packages/tensorflow_core/python/framework/ops.py", line 1273, in internal_convert_to_tensor
    (dtype.name, value.dtype.name, value))
ValueError: Tensor conversion requested dtype float32 for Tensor with dtype int32: <tf.Tensor 'strided_slice_15:0' shape=() dtype=int32>
```