### PR TITLE
initialize coco metric when filename is not present

### DIFF
--- a/efficientdet/coco_metric.py
+++ b/efficientdet/coco_metric.py
@@ -88,6 +88,7 @@ class EvaluationMetric():
     if self.filename:
       self.coco_gt = COCO(self.filename)
     else:
+      self.coco_gt = COCO()
       self.coco_gt.dataset = self.dataset
       self.coco_gt.createIndex()
 


### PR DESCRIPTION
In evaluation function when filename is not present we need to initialize Coco there as well.
cc @mingxingtan 