### PR TITLE
Fix preprocessing error in keras infer

### DIFF
--- a/efficientdet/keras/infer.py
+++ b/efficientdet/keras/infer.py
@@ -65,7 +65,7 @@ def main(_):
   def f(imgs):
     return model(imgs, training=False, post_mode='global')
 
-  boxes, scores, classes, valid_len = f(imgs)
+  boxes, scores, classes, valid_len = f(tf.convert_to_tensor(imgs, dtype=tf.uint8))
 
   # Visualize results.
   for i, img in enumerate(imgs):


### PR DESCRIPTION
Somehow when a list of numpy arrays is passed to _preprocess, map_fn will use dim[0] of the first element in the list as n_static. A quick fix by converting the list to 4D tensor (for single image).