### PR TITLE
Separating input and output model checkpoint, avoiding file overwriting.

### DIFF
--- a/efficientdet/keras/train.py
+++ b/efficientdet/keras/train.py
@@ -62,6 +62,9 @@ flags.DEFINE_bool(
     'and this flag has no effect.')
 flags.DEFINE_string('model_dir', None, 'Location of model_dir')
 
+flags.DEFINE_string('ckpt', None,
+                    'Start training from this EfficientDet checkpoint.')
+
 flags.DEFINE_string(
     'hparams', '', 'Comma separated k=v pairs of hyperparameters or a module'
     ' containing attributes to use as hyperparameters.')
@@ -208,16 +211,17 @@ def main(_):
             'seg_loss':
                 tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
         })
-    ckpt_path = tf.train.latest_checkpoint(FLAGS.model_dir)
+    ckpt_path = tf.train.latest_checkpoint(FLAGS.ckpt)
     if ckpt_path:
       model.load_weights(ckpt_path)
+    os.makedirs(FLAGS.model_dir, exist_ok=True)
     model.fit(
         get_dataset(True, params=params),
         epochs=params['num_epochs'],
         steps_per_epoch=steps_per_epoch,
         callbacks=train_lib.get_callbacks(params, FLAGS.profile),
         validation_data=get_dataset(False, params=params))
-  model.save_weights(os.path.join(FLAGS.model_dir, 'model'))
+  model.save_weights(os.path.join(FLAGS.model_dir, 'ckpt-final'))
 
 
 if __name__ == '__main__':

--- a/efficientdet/keras/train.py
+++ b/efficientdet/keras/train.py
@@ -62,7 +62,7 @@ flags.DEFINE_bool(
     'and this flag has no effect.')
 flags.DEFINE_string('model_dir', None, 'Location of model_dir')
 
-flags.DEFINE_string('ckpt', None,
+flags.DEFINE_string('pretrained_ckpt', None,
                     'Start training from this EfficientDet checkpoint.')
 
 flags.DEFINE_string(
@@ -211,7 +211,7 @@ def main(_):
             'seg_loss':
                 tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
         })
-    ckpt_path = tf.train.latest_checkpoint(FLAGS.ckpt)
+    ckpt_path = tf.train.latest_checkpoint(FLAGS.pretrained_ckpt)
     if ckpt_path:
       model.load_weights(ckpt_path)
     os.makedirs(FLAGS.model_dir, exist_ok=True)

--- a/efficientdet/keras/train_lib.py
+++ b/efficientdet/keras/train_lib.py
@@ -246,10 +246,14 @@ def get_callbacks(params, profile=False):
   tb_callback = tf.keras.callbacks.TensorBoard(
       log_dir=params['model_dir'], profile_batch=2 if profile else 0)
   ckpt_callback = tf.keras.callbacks.ModelCheckpoint(
-      params['model_dir'], verbose=1, save_weights_only=True)
+      f"{params['model_dir']}/ckpt", verbose=1, save_weights_only=True)
   early_stopping = tf.keras.callbacks.EarlyStopping(
       monitor='val_loss', min_delta=0, patience=10, verbose=1)
-  callbacks = [tb_callback, ckpt_callback, early_stopping]
+  callbacks = [
+    tb_callback,
+    ckpt_callback,
+    early_stopping,
+  ]
   if params.get('sample_image', None):
     display_callback = DisplayCallback(
         params.get('sample_image', None),


### PR DESCRIPTION
Currently, the flag `model_dir` is used for both loading and saving the checkpoint file in the keras training script. This will lead to a problem of overwriting the original checkpoint.

For example, if `model_dir=ckpt/efficientdet-d0`, the script will look for the latest checkpoint file inside the directory, where the filename is `model.*` if the pretrain weight downloaded from the repo is used. During training, checkpoint files are saved at `ckpt/efficientdet-d0.*`, at the same level of the original `model_dir`. After training is finished, the final checkpoint files called `model.*` are saved inside `model_dir`, potentially overwriting the original checkpoint, which might be intended to be kept.

With this PR, another flag called `ckpt` is created to take the directory of pretrained checkpoint directory and `model_dir` is continued to be used as output folder. 

Some other behavior changes including:

* Creating `model_dir` if not exist
* Intermediate checkpoint file is saved inside `model_dir`, named `ckpt.*`
* Final checkpoint file is also saved inside `model_dir`, named `ckpt-final.*`

Future work can include:
* Have the option of keeping multiple intermediate checkpoint files