### PR TITLE
Fix an issue which prevents EarlyStopping callback

### DIFF
--- a/efficientdet/keras/train_lib.py
+++ b/efficientdet/keras/train_lib.py
@@ -508,7 +508,8 @@ class EfficientDetNetTrain(efficientdet_keras.EfficientDetNet):
       total_loss = reg_l2loss
       loss_vals = {}
       if 'object_detection' in self.config.heads:
-        det_loss = self._detection_loss(cls_outputs, box_outputs, labels, loss_vals)
+        det_loss = self._detection_loss(cls_outputs, box_outputs, labels,
+                                        loss_vals)
         total_loss += det_loss
       if 'segmentation' in self.config.heads:
         seg_loss_layer = self.loss['seg_loss']
@@ -559,7 +560,8 @@ class EfficientDetNetTrain(efficientdet_keras.EfficientDetNet):
     total_loss = reg_l2loss
     loss_vals = {}
     if 'object_detection' in self.config.heads:
-      det_loss = self._detection_loss(cls_outputs, box_outputs, labels, loss_vals)
+      det_loss = self._detection_loss(cls_outputs, box_outputs, labels,
+                                      loss_vals)
       total_loss += det_loss
     if 'segmentation' in self.config.heads:
       seg_loss_layer = self.loss['seg_loss']

--- a/efficientdet/keras/train_lib.py
+++ b/efficientdet/keras/train_lib.py
@@ -481,7 +481,7 @@ class EfficientDetNetTrain(efficientdet_keras.EfficientDetNet):
     loss_vals['det_loss'] = total_loss
     loss_vals['cls_loss'] = cls_loss
     loss_vals['box_loss'] = box_loss
-    return total_loss, cls_loss, box_loss, box_iou_loss
+    return total_loss
 
   def train_step(self, data):
     """Train step.
@@ -508,8 +508,7 @@ class EfficientDetNetTrain(efficientdet_keras.EfficientDetNet):
       total_loss = reg_l2loss
       loss_vals = {}
       if 'object_detection' in self.config.heads:
-        det_loss = (
-            self._detection_loss(cls_outputs, box_outputs, labels, loss_vals))
+        det_loss = self._detection_loss(cls_outputs, box_outputs, labels, loss_vals)
         total_loss += det_loss
       if 'segmentation' in self.config.heads:
         seg_loss_layer = self.loss['seg_loss']
@@ -560,9 +559,8 @@ class EfficientDetNetTrain(efficientdet_keras.EfficientDetNet):
     total_loss = reg_l2loss
     loss_vals = {}
     if 'object_detection' in self.config.heads:
-      det_loss = (
-          self._detection_loss(cls_outputs, box_outputs, labels, loss_vals))
-      total_loss += det_loss[0]
+      det_loss = self._detection_loss(cls_outputs, box_outputs, labels, loss_vals)
+      total_loss += det_loss
     if 'segmentation' in self.config.heads:
       seg_loss_layer = self.loss['seg_loss']
       seg_loss = seg_loss_layer(labels['image_masks'], seg_outputs)

--- a/efficientdet/keras/train_lib.py
+++ b/efficientdet/keras/train_lib.py
@@ -562,7 +562,7 @@ class EfficientDetNetTrain(efficientdet_keras.EfficientDetNet):
     if 'object_detection' in self.config.heads:
       det_loss = (
           self._detection_loss(cls_outputs, box_outputs, labels, loss_vals))
-      total_loss += det_loss
+      total_loss += det_loss[0]
     if 'segmentation' in self.config.heads:
       seg_loss_layer = self.loss['seg_loss']
       seg_loss = seg_loss_layer(labels['image_masks'], seg_outputs)


### PR DESCRIPTION
When `val_loss` is used as metric for `EarlyStopping` monitoring, it only takes in scalar for comparison, raising the following error: `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`, since `loss_vals['loss']` is a 1st order tensor. A simple fix is to only add `det_loss[0]` to `total_loss`.