### PR TITLE
small bug fix: model exporting type cast error

### DIFF
--- a/efficientdet/inference.py
+++ b/efficientdet/inference.py
@@ -236,7 +236,7 @@ def det_post_process(params: Dict[Any, Any], cls_outputs: Dict[int, tf.Tensor],
         params, cls_outputs, box_outputs, scales)
 
   batch_size = tf.shape(cls_outputs[params['min_level']])[0]
-  img_ids = tf.expand_dims(tf.range(0, batch_size, dtype=nms_scores.dtype), -1)
+  img_ids = tf.expand_dims(tf.cast(tf.range(0, batch_size), nms_scores.dtype), -1)
   detections = [
       img_ids * tf.ones_like(nms_scores),
       nms_boxes[:, :, 0],


### PR DESCRIPTION
I was following the notebook tutorial and an error occurred when I was trying to export my model using model_inspect.py:

```
python model_inspect.py \
	--runmode=saved_model \
	--model_name=$MODEL \
	--ckpt_path=$MODEL_DIR_TMP \
	--saved_model_dir=$MODEL_DIR_EXPORT
```

The exception prints out:

```
Traceback (most recent call last):
  File "model_inspect.py", line 520, in <module>
    app.run(main)
  File "/home/ml6/projects/CCPD/ccpd-efficientdet/source/venv/lib/python3.6/site-packages/absl/app.py", line 300, in run
    _run_main(main, args)
  File "/home/ml6/projects/CCPD/ccpd-efficientdet/source/venv/lib/python3.6/site-packages/absl/app.py", line 251, in _run_main
    sys.exit(main(argv))
  File "model_inspect.py", line 513, in main
    trace_filename=FLAGS.trace_filename)
  File "model_inspect.py", line 462, in run_model
    self.export_saved_model(**config_dict)
  File "model_inspect.py", line 150, in export_saved_model
    driver.build()
  File "/home/ml6/projects/CCPD/ccpd-efficientdet/source/efficientdet/inference.py", line 437, in build
    detections = det_post_process(params, class_outputs, box_outputs, scales)
  File "/home/ml6/projects/CCPD/ccpd-efficientdet/source/efficientdet/inference.py", line 239, in det_post_process
    img_ids = tf.expand_dims(tf.range(0, batch_size, dtype=nms_scores.dtype), -1)
  File "/home/ml6/projects/CCPD/ccpd-efficientdet/source/venv/lib/python3.6/site-packages/tensorflow_core/python/ops/math_ops.py", line 1430, in range
    limit = ops.convert_to_tensor(limit, dtype=dtype, name="limit")
  File "/home/ml6/projects/CCPD/ccpd-efficientdet/source/venv/lib/python3.6/site-packages/tensorflow_core/python/framework/ops.py", line 1290, in convert_to_tensor
    (dtype.name, value.dtype.name, value))
ValueError: Tensor conversion requested dtype float32 for Tensor with dtype int32: <tf.Tensor 'strided_slice_21:0' shape=() dtype=int32>
```

The error happens at 238-239 lines in inference.py:

```
  batch_size = tf.shape(cls_outputs[params['min_level']])[0]
  img_ids = tf.expand_dims(tf.range(0, batch_size, dtype=nms_scores.dtype), -1)
```

batch_size has type int32 whilst nms_scores.dtype is tf.float32. It seems like tf.range cannot implicitly convert int32 to float32 here. So the exception is thrown. My TensorFlow version is 2.1.0.

Hence, instead of specifying dtype parameter to tf.range, use a tf.cast can solve this problem. Everything else works as expected.

It's a small bug but really cuts the flow of the notebook tutorial. Hopefully it gets fixed soon.

Thanks!