### PR TITLE
fixed TypeError: not all arguments converted during string formatting

### DIFF
--- a/efficientdet/main.py
+++ b/efficientdet/main.py
@@ -350,7 +350,7 @@ def main(_):
           step * FLAGS.train_batch_size // FLAGS.num_examples_per_epoch)
       logging.info('found ckpt at step %d (epoch %d)', step, current_epoch)
     except (IndexError, TypeError):
-      logging.info("Folder has no ckpt with valid step.", FLAGS.model_dir)
+      logging.info("Folder has no ckpt with valid step. Folder: %s", FLAGS.model_dir)
       current_epoch = 0
 
     epochs_per_cycle = 1  # higher number has less graph construction overhead.


### PR DESCRIPTION
If folder has no checkpoint or folder does not exists, then another error occurres within exception. Training still works, only prevents potential confusion.

My versions:
- TF 2.3.0
- Python 3.6.9

```
--- Logging error ---
Traceback (most recent call last):
  File "xxx/projects/automl-efficientdet/efficientdet/main.py", line 348, in main                                                                                                                                                step = int(os.path.basename(ckpt).split("-")[1])
IndexError: list index out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/logging/__init__.py", line 994, in emit
    msg = self.format(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 840, in format
    return fmt.format(record)
  File "xxx/envs/automl-efficientdet/lib/python3.6/site-packages/absl/logging/__init__.py", line 938, in format
    return prefix + super(PythonFormatter, self).format(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 577, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.6/logging/__init__.py", line 338, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "xxx/projects/automl-efficientdet/efficientdet/main.py", line 381, in <module>
    app.run(main)
  File "xxx/envs/automl-efficientdet/lib/python3.6/site-packages/absl/app.py", line 299, in run
    _run_main(main, args)
  File "xxx/envs/automl-efficientdet/lib/python3.6/site-packages/absl/app.py", line 250, in _run_main
    sys.exit(main(argv))
  File "xxx/projects/automl-efficientdet/efficientdet/main.py", line 353, in main
    logging.info("Folder has no ckpt with valid step.", FLAGS.model_dir)
  File "xxx/envs/automl-efficientdet/lib/python3.6/site-packages/absl/logging/__init__.py", line 338, in info
    log(INFO, msg, *args, **kwargs)
  File "xxx/envs/automl-efficientdet/lib/python3.6/site-packages/absl/logging/__init__.py", line 485, in log
    _absl_logger.log(standard_level, msg, *args, **kwargs)
  File "xxx/envs/automl-efficientdet/lib/python3.6/site-packages/absl/logging/__init__.py", line 1048, in log
    super(ABSLLogger, self).log(level, msg, *args, **kwargs)
  File "/usr/lib/python3.6/logging/__init__.py", line 1374, in log
    self._log(level, msg, args, **kwargs)
  File "/usr/lib/python3.6/logging/__init__.py", line 1444, in _log
    self.handle(record)
  File "xxx/envs/automl-efficientdet/lib/python3.6/site-packages/absl/logging/__init__.py", line 1065, in handle
    self.callHandlers(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 1516, in callHandlers
    hdlr.handle(record)
  File "xxx/envs/automl-efficientdet/lib/python3.6/site-packages/absl/logging/__init__.py", line 901, in handle
    return self._current_handler.handle(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 865, in handle
    self.emit(record)
  File "xxx/envs/automl-efficientdet/lib/python3.6/site-packages/absl/logging/__init__.py", line 838, in emit
    super(PythonHandler, self).emit(record)
Message: 'Folder has no ckpt with valid step.'
Arguments: ('xxx/automl-efficientdet/logs/efficientdet-d0',)
-----------------------------------------------------

```