### PR TITLE
Simplify estimator train_and_eval.

### DIFF
--- a/efficientdet/det_model_fn.py
+++ b/efficientdet/det_model_fn.py
@@ -343,6 +343,7 @@ def _model_fn(features, labels, mode, params, model, variable_filter_fn=None):
   """
   utils.image('input_image', features)
   training_hooks = []
+  params['is_training_bn'] = (mode == tf.estimator.ModeKeys.TRAIN)
 
   if params['use_keras_model']:
     def model_fn(inputs):


### PR DESCRIPTION
After asking TF team, looks like tf.estimator.train_and_eval is recommended for continuous train_and_eval, as it avoids rebuild graph for every train.