### PR TITLE
remove trainable

### DIFF
--- a/efficientdet/keras/efficientdet_keras.py
+++ b/efficientdet/keras/efficientdet_keras.py
@@ -124,8 +124,7 @@ class FNode(tf.keras.layers.Layer):
       name = 'WSM' + ('' if i == 0 else '_' + str(i))
       self.vars.append(
           self.add_weight(
-              initializer=initializer, name=name,
-              trainable=self.is_training_bn))
+              initializer=initializer, name=name))
 
   def build(self, feats_shape):
     for i, input_offset in enumerate(self.inputs_offsets):


### PR DESCRIPTION
Fix #676 
Only happens when moving average decay = 0 and use_keras_model = True.
Reason: utils.get_ema_variable only return trainable variables that cause WSM variables aren't restored when set is_training_bn = False.