### PR TITLE
Improve handling of custom label maps

### DIFF
--- a/efficientdet/dataset/create_pascal_tfrecord.py
+++ b/efficientdet/dataset/create_pascal_tfrecord.py
@@ -275,15 +275,17 @@ def main(_):
       'categories': []
   }
   for year in years:
+    example_class = list(label_map_dict.keys())[1]
+    examples_path = os.path.join(data_dir, year, 'ImageSets', 'Main',
+                                 example_class + '_' + FLAGS.set + '.txt')
+    examples_list = tfrecord_util.read_examples_list(examples_path)
+    annotations_dir = os.path.join(data_dir, year, FLAGS.annotations_dir)
+
     for class_name, class_id in label_map_dict.items():
       cls = {'supercategory': 'none', 'id': class_id, 'name': class_name}
       ann_json_dict['categories'].append(cls)
 
     logging.info('Reading from PASCAL %s dataset.', year)
-    examples_path = os.path.join(data_dir, year, 'ImageSets', 'Main',
-                                 'aeroplane_' + FLAGS.set + '.txt')
-    annotations_dir = os.path.join(data_dir, year, FLAGS.annotations_dir)
-    examples_list = tfrecord_util.read_examples_list(examples_path)
     for idx, example in enumerate(examples_list):
       if FLAGS.num_images and idx >= FLAGS.num_images:
         break

--- a/efficientdet/dataset/create_pascal_tfrecord.py
+++ b/efficientdet/dataset/create_pascal_tfrecord.py
@@ -251,7 +251,11 @@ def main(_):
   if FLAGS.year != 'merged':
     years = [FLAGS.year]
 
-  logging.info('writing to output path: %s', FLAGS.output_path)
+  output_dir = os.path.dirname(FLAGS.output_path)
+  if not tf.io.gfile.exists(output_dir):
+    tf.io.gfile.makedirs(output_dir)
+  logging.info('Writing to output directory: %s', output_dir)
+
   writers = [
       tf.python_io.TFRecordWriter(FLAGS.output_path + '-%05d-of-%05d.tfrecord' %
                                   (i, FLAGS.num_shards))

--- a/efficientdet/dataset/tfrecord_util.py
+++ b/efficientdet/dataset/tfrecord_util.py
@@ -71,7 +71,7 @@ def recursive_parse_xml_to_dict(xml):
   Returns:
     Python dictionary holding XML contents.
   """
-  if not xml:
+  if len(xml) == 0:
     return {xml.tag: xml.text}
   result = {}
   for child in xml:


### PR DESCRIPTION
Although the conversion script supports loading custom label map (via the `label_map_json_path` flag), it always tries to load the list of examples from `aeroplane_<set>.txt` file. This fails in most cases (unless the custom dataset actually does contain the `aeroplane` class).

This PR modifies the behavior and instead of using hard-coded class, it picks the class directly from `label_map_dict`.

It also creates the output directory, if it doesn't exist.