### PR TITLE
default gradient_checkpointing_list ['AddN', 'Add_']

### DIFF
--- a/efficientdet/README.md
+++ b/efficientdet/README.md
@@ -385,7 +385,7 @@ Check these links for a high-level idea of what gradient checkpointing is doing:
 
 **gradient_checkpointing: True**
 
-If set to True, strings defined by gradient_checkpointing_list (["Add"] by default) are searched in the tensors names and any tensors that match a string from the list are kept as checkpoints. When this option is used the standard tensorflow.python.ops.gradients method is being replaced with a custom method.
+If set to True, strings defined by gradient_checkpointing_list (["Add\_", "AddN"] by default) are searched in the tensors names and any tensors that match a string from the list are kept as checkpoints. When this option is used the standard tensorflow.python.ops.gradients method is being replaced with a custom method.
 
 Testing shows that:
 * On d4 network with batch-size of 1 (mixed precision enabled) it takes only 1/3.2 of memory with roughly 32% slower computation

--- a/efficientdet/hparams_config.py
+++ b/efficientdet/hparams_config.py
@@ -294,13 +294,13 @@ def default_detection_configs():
   # other nodes, so it improves the speed
   # The disadvantage of adding more ops is it requires more GPU memory to cache
   # the computation
-  # The default is ["Add"] as it is a "bottleneck" node in the backbone network
+  # The default is ["Add_", "AddN"] as it is a "bottleneck" node in the backbone network
   # EfficientNet. It has been tested and works reasonably well:
   # 1) For d4 network with batch-size of 1 (mixed precision enabled) it takes
   # only 1/3.2 of memory with roughly 32% slower computation.
   # 2) It allows to train a d6 network with batch size of 2 and mixed precision
   # on a 11Gb (2080ti) GPU, without this option there is an OOM error
-  h.gradient_checkpointing_list = ["Add"]
+  h.gradient_checkpointing_list = ["Add_", "AddN"]
 
   # enable memory logging for NVIDIA cards
   h.nvgpu_logging = False

--- a/efficientdet/hparams_config.py
+++ b/efficientdet/hparams_config.py
@@ -294,8 +294,9 @@ def default_detection_configs():
   # other nodes, so it improves the speed
   # The disadvantage of adding more ops is it requires more GPU memory to cache
   # the computation
-  # The default is ["Add_", "AddN"] as it is a "bottleneck" node in the backbone network
-  # EfficientNet. It has been tested and works reasonably well:
+  # The default are ["Add_", "AddN"] as these are "bottleneck" nodes
+  # in the backbone network EfficientNet and in FPN network
+  # It has been tested and works reasonably well:
   # 1) For d4 network with batch-size of 1 (mixed precision enabled) it takes
   # only 1/3.2 of memory with roughly 32% slower computation.
   # 2) It allows to train a d6 network with batch size of 2 and mixed precision


### PR DESCRIPTION
This is a better default for gradient_checkpointing_list.

Currently it is ['Add'] and, therefore, BiasAdd nodes are included in checkpoints - this was unintended as the intention was to include only "bottleneck" nodes.

With the new default, the number of checkpoints to include decreases (e.g. for d6 it goes from ~300 to ~100) so it uses slightly less memory. I am not able to measure exact decrease in memory usage as I noticed that tf reserves more memory (all available memory) than it actually needs. But I am able to train more models. E.g. d6 with batch 2 with XLA enabled was giving me OOM and now it trains fine. For some not fully understood reason (maybe saving/reading checkpoints from cache is a more expensive operation than I originally thought) the overall speed of the forward+backward pass not only does not go down but actually goes up. 

There might be even better defaults. I tried some graph vertex cut algorithms (JA-BE-JA-VC) but that did not give a better result thus far