### PR TITLE
fix nms numeric stable bug

### DIFF
--- a/efficientdet/README.md
+++ b/efficientdet/README.md
@@ -417,4 +417,25 @@ python dataset/inspect_tfrecords.py --file_pattern dataset/sample.record\
 * save_samples_dir: save dir.
 * eval: flag for eval data.
 
+## 13. Export to ONNX
+(1)  Install tf2onnx
+```
+pip install tf2onnx
+```
+(2) Set nms configs (onnx doesn't support soft nms, use normal nms instead):
+```
+nms_configs:
+  method: 'hard'
+  iou_thresh: 0.5  # use the default value based on method.
+  score_thresh: 0.
+  sigma: 0.0
+  pyfunc: False
+  max_nms_inputs: 0
+  max_output_size: 100
+```
+(3) Export to onnx from saved_model
+```
+python -m tf2onnx.convert --saved-model=<saved model directory> --output=<onnx filename> --opset=11
+```
+
 NOTE: this is not an official Google product.

--- a/efficientdet/README.md
+++ b/efficientdet/README.md
@@ -417,25 +417,4 @@ python dataset/inspect_tfrecords.py --file_pattern dataset/sample.record\
 * save_samples_dir: save dir.
 * eval: flag for eval data.
 
-## 13. Export to ONNX
-(1)  Install tf2onnx
-```
-pip install tf2onnx
-```
-(2) Set nms configs (onnx doesn't support soft nms, use normal nms instead):
-```
-nms_configs:
-  method: 'hard'
-  iou_thresh: 0.5  # use the default value based on method.
-  score_thresh: 0.
-  sigma: 0.0
-  pyfunc: False
-  max_nms_inputs: 0
-  max_output_size: 100
-```
-(3) Export to onnx from saved_model
-```
-python -m tf2onnx.convert --saved-model=<saved model directory> --output=<onnx filename> --opset=11
-```
-
 NOTE: this is not an official Google product.

--- a/efficientdet/keras/README.md
+++ b/efficientdet/keras/README.md
@@ -350,4 +350,7 @@ nms_configs:
 python -m tf2onnx.convert --saved-model=<saved model directory> --output=<onnx filename> --opset=11
 ```
 
+## 14. Debug
+Just add ```--debug``` after command, then you could use pdb debug the model with eager execution and deterministic operations.
+
 NOTE: this is not an official Google product.

--- a/efficientdet/keras/README.md
+++ b/efficientdet/keras/README.md
@@ -329,4 +329,25 @@ python dataset/inspect_tfrecords.py --file_pattern dataset/sample.record\
 * save_samples_dir: save dir.
 * eval: flag for eval data.
 
+## 13. Export to ONNX
+(1)  Install tf2onnx
+```
+pip install tf2onnx
+```
+(2) Set nms configs (onnx doesn't support soft nms, use normal nms instead):
+```
+nms_configs:
+  method: 'hard'
+  iou_thresh: 0.5  # use the default value based on method.
+  score_thresh: 0.
+  sigma: 0.0
+  pyfunc: False
+  max_nms_inputs: 0
+  max_output_size: 100
+```
+(3) Export to onnx from saved_model
+```
+python -m tf2onnx.convert --saved-model=<saved model directory> --output=<onnx filename> --opset=11
+```
+
 NOTE: this is not an official Google product.

--- a/efficientdet/keras/efficientdet_keras.py
+++ b/efficientdet/keras/efficientdet_keras.py
@@ -962,6 +962,9 @@ class EfficientDetModel(EfficientDetNet):
     if mode == 'per_class':
       return postprocess.postprocess_per_class(self.config.as_dict(),
                                                cls_outputs, box_outputs, scales)
+    if mode == 'combined':
+      return postprocess.postprocess_combined(self.config.as_dict(),
+                                              cls_outputs, box_outputs, scales)
     if mode == 'tflite':
       if scales is not None:
         # pre_mode should be None for TFLite.

--- a/efficientdet/keras/efficientdet_keras.py
+++ b/efficientdet/keras/efficientdet_keras.py
@@ -956,10 +956,6 @@ class EfficientDetModel(EfficientDetNet):
     if not mode:
       return cls_outputs, box_outputs
 
-    # TODO(tanmingxing): remove this cast once FP16 works postprocessing.
-    cls_outputs = [tf.cast(i, tf.float32) for i in cls_outputs]
-    box_outputs = [tf.cast(i, tf.float32) for i in box_outputs]
-
     if mode == 'global':
       return postprocess.postprocess_global(self.config.as_dict(), cls_outputs,
                                             box_outputs, scales)

--- a/efficientdet/keras/inference.py
+++ b/efficientdet/keras/inference.py
@@ -152,7 +152,8 @@ class ServingDriver:
                ckpt_path: Text = None,
                batch_size: int = 1,
                only_network: bool = False,
-               model_params: Dict[Text, Any] = None):
+               model_params: Dict[Text, Any] = None,
+               debug:bool = False):
     """Initialize the inference driver.
 
     Args:
@@ -167,6 +168,7 @@ class ServingDriver:
     self.ckpt_path = ckpt_path
     self.batch_size = batch_size
     self.only_network = only_network
+    self.debug = debug
 
     self.params = hparams_config.get_detection_config(model_name).as_dict()
 
@@ -209,6 +211,8 @@ class ServingDriver:
     util_keras.restore_ckpt(self.model, self.ckpt_path,
                             self.params['moving_average_decay'],
                             skip_mismatch=False)
+    if self.debug:
+      tf.config.run_functions_eagerly(self.debug)
 
   def visualize(self, image, boxes, classes, scores, **kwargs):
     """Visualize prediction on image."""

--- a/efficientdet/keras/inspector.py
+++ b/efficientdet/keras/inspector.py
@@ -67,7 +67,6 @@ FLAGS = flags.FLAGS
 
 
 def main(_):
-  tf.config.run_functions_eagerly(FLAGS.debug)
   devices = tf.config.list_physical_devices('GPU')
   for device in devices:
     tf.config.experimental.set_memory_growth(device, True)

--- a/efficientdet/keras/postprocess.py
+++ b/efficientdet/keras/postprocess.py
@@ -22,6 +22,7 @@ import tensorflow as tf
 import nms_np
 import utils
 from keras import anchors
+from keras import util_keras
 T = tf.Tensor  # a shortcut for typing check.
 CLASS_OFFSET = 1
 # TFLite-specific constants.
@@ -220,8 +221,8 @@ def postprocess_combined(params, cls_outputs, box_outputs, image_scales=None):
   Returns:
     A tuple of batch level (boxes, scores, classess, valid_len) after nms.
   """
-  cls_outputs = to_list(cls_outputs)
-  box_outputs = to_list(box_outputs)
+  cls_outputs = util_keras.fp16_to_fp32_nested(to_list(cls_outputs))
+  box_outputs = util_keras.fp16_to_fp32_nested(to_list(box_outputs))
   # Don't filter any outputs because combine_nms need the raw information.
   boxes, scores, _ = pre_nms(params, cls_outputs, box_outputs, topk=False)
 

--- a/efficientdet/keras/postprocess.py
+++ b/efficientdet/keras/postprocess.py
@@ -221,6 +221,7 @@ def postprocess_combined(params, cls_outputs, box_outputs, image_scales=None):
   Returns:
     A tuple of batch level (boxes, scores, classess, valid_len) after nms.
   """
+  # Combined nms only has float32 kernel
   cls_outputs = util_keras.fp16_to_fp32_nested(to_list(cls_outputs))
   box_outputs = util_keras.fp16_to_fp32_nested(to_list(box_outputs))
   # Don't filter any outputs because combine_nms need the raw information.

--- a/efficientdet/keras/train.py
+++ b/efficientdet/keras/train.py
@@ -183,6 +183,8 @@ def main(_):
     if FLAGS.batch_size % len(gpus):
       raise ValueError('Batch size divide gpus number must be interger, but got %f', FLAGS.batch_size / len(gpus))
     if platform.system() == 'Windows':
+      # Windows doesn't support nccl use HierarchicalCopyAllReduce instead
+      # TODO(fsx950223): investigate HierarchicalCopyAllReduce performance issue
       cross_device_ops = tf.distribute.HierarchicalCopyAllReduce()
     else:
       cross_device_ops = None

--- a/efficientdet/keras/train.py
+++ b/efficientdet/keras/train.py
@@ -165,7 +165,6 @@ def main(_):
       tf.config.experimental.set_memory_growth(gpu, True)
 
   if FLAGS.debug:
-    tf.config.run_functions_eagerly(True)
     tf.debugging.set_log_device_placement(True)
     os.environ['TF_DETERMINISTIC_OPS'] = '1'
     tf.random.set_seed(FLAGS.tf_random_seed)
@@ -240,9 +239,11 @@ def main(_):
     else:
       model = train_lib.EfficientDetNetTrain(config=config)
     model = setup_model(model, config)
+    if FLAGS.debug:
+      tf.config.run_functions_eagerly(True)
     if FLAGS.pretrained_ckpt and not FLAGS.hub_module_url:
       ckpt_path = tf.train.latest_checkpoint(FLAGS.pretrained_ckpt)
-      util_keras.restore_ckpt(model, ckpt_path, config.moving_average_decay)
+      util_keras.restore_ckpt(model, ckpt_path, config.moving_average_decay, exclude_layers=['class_net'])
     init_experimental(config)
     if 'train' in FLAGS.mode:
       val_dataset = get_dataset(False, config) if 'eval' in FLAGS.mode else None


### PR DESCRIPTION
I fix the nms bug on float16 kernel, I have uploaded the code on https://github.com/fsx950223/tensorflow/commits/non_max_suppression.
Here is my minimal example:
```
import tensorflow as tf
boxes_f = open('/tensorflow_src/tensorflow/examples/tests/boxes.tensor', 'rb').read()
scores_f = open('/tensorflow_src/tensorflow/examples/tests/scores.tensor', 'rb').read()
boxes = tf.io.parse_tensor(boxes_f, tf.float16)
scores = tf.io.parse_tensor(scores_f, tf.float16)
nms_top_idx, nms_scores, nms_valid_lens = tf.raw_ops.NonMaxSuppressionV5(
    boxes=boxes,
    scores=scores,
    max_output_size=100,
    iou_threshold=1.0,
    score_threshold=0.3,
    soft_nms_sigma=(0.5 / 2),
    pad_to_max_output_size=True)
tf.print(nms_top_idx, nms_scores, nms_valid_lens)
```
You can download tensors from [boxes](https://drive.google.com/file/d/1vSM0-Vy8ivG0PakERWLvJinhDm41zhco/view?usp=sharing), [scores](https://drive.google.com/file/d/1qbVxRFp_jSTKY_zYvvzvpIkJJ42Auq9S/view?usp=sharing).

Could you review it and test internals?