### PR TITLE
Fix inspectors

### DIFF
--- a/efficientdet/dataset/inspect_tfrecords.py
+++ b/efficientdet/dataset/inspect_tfrecords.py
@@ -81,16 +81,14 @@ class RecordInspect:
     for i, zip_data in enumerate(zip(gt_data, images, scales)):
       gt, image, scale = zip_data
       boxes = gt[:, :4]
-      boxes = boxes[boxes[..., 0] > 0].numpy()
+      boxes = boxes[np.any(boxes > 0, axis=1)].numpy()
       if boxes.shape[0] > 0:
         classes = gt[:boxes.shape[0], -1].numpy()
         try:
-          display_str_list_list = map(lambda idx: self.cls_to_label[idx],
-                                      np.asarray(classes, dtype=np.int))
-          display_str_list_list = np.reshape(
-              np.asarray(list(display_str_list_list)), (-1, 1)).tolist()
+          category_index = {idx: {'id': idx, 'name': self.cls_to_label[idx]}
+                            for idx in np.asarray(classes, dtype=np.int)}
         except Exception:  # pylint: disable=broad-except
-          display_str_list_list = ()
+          category_index = {}
 
         # unnormalize image.
         image *= scale_image
@@ -102,13 +100,15 @@ class RecordInspect:
         # scale to image_size
         boxes *= scale.numpy()
 
-        # normalize boxes
-        boxes[:, (0, 2)] = boxes[:, (0, 2)] / image.shape[0]
-        boxes[:, (1, 3)] = boxes[:, (1, 3)] / image.shape[1]
-
+        image = vis_utils.visualize_boxes_and_labels_on_image_array(
+          image,
+          boxes=boxes,
+          classes=classes.astype(int),
+          scores=np.ones(boxes.shape[0]),
+          category_index=category_index,
+          line_thickness=2,
+          skip_scores=True)
         image = Image.fromarray(image)
-        vis_utils.draw_bounding_boxes_on_image(
-            image, boxes, display_str_list_list=display_str_list_list)
         image.save(os.path.join(FLAGS.save_samples_dir, f'sample{i}.jpg'))
 
 

--- a/efficientdet/keras/inspector.py
+++ b/efficientdet/keras/inspector.py
@@ -103,8 +103,7 @@ def main(_):
     if FLAGS.saved_model_dir:
       driver.load(FLAGS.saved_model_dir)
       if FLAGS.saved_model_dir.endswith('.tflite'):
-        image_size = utils.parse_image_size(model_config.image_size)
-        image_arrays = tf.image.resize_with_pad(image_arrays, *image_size)
+        image_arrays = tf.image.resize_with_pad(image_arrays, *model_config.image_size)
         image_arrays = tf.cast(image_arrays, tf.uint8)
     detections_bs = driver.serve(image_arrays)
     boxes, scores, classes, _ = tf.nest.map_structure(np.array, detections_bs)
@@ -135,8 +134,9 @@ def main(_):
       # use synthetic data if no image is provided.
       image_arrays = tf.ones((batch_size, *model_config.image_size, 3),
                              dtype=tf.uint8)
-      if FLAGS.only_network:
-        image_arrays = tf.cast(image_arrays, tf.float32)
+    if FLAGS.only_network:
+      image_arrays = tf.image.convert_image_dtype(image_arrays, tf.float32)
+      image_arrays = tf.image.resize(image_arrays, model_config.image_size)
     driver.benchmark(image_arrays, FLAGS.bm_runs, FLAGS.trace_filename)
   elif FLAGS.mode == 'dry':
     # transfer to tf2 format ckpt

--- a/efficientdet/keras/inspector.py
+++ b/efficientdet/keras/inspector.py
@@ -135,6 +135,8 @@ def main(_):
       # use synthetic data if no image is provided.
       image_arrays = tf.ones((batch_size, *model_config.image_size, 3),
                              dtype=tf.uint8)
+      if FLAGS.only_network:
+        image_arrays = tf.cast(image_arrays, tf.float32)
     driver.benchmark(image_arrays, FLAGS.bm_runs, FLAGS.trace_filename)
   elif FLAGS.mode == 'dry':
     # transfer to tf2 format ckpt
@@ -153,7 +155,7 @@ def main(_):
     if FLAGS.output_video:
       frame_width, frame_height = int(cap.get(3)), int(cap.get(4))
       out_ptr = cv2.VideoWriter(FLAGS.output_video,
-                                cv2.VideoWriter_fourcc('m', 'p', '4', 'v'), 25,
+                                cv2.VideoWriter_fourcc('m', 'p', '4', 'v'), cap.get(5),
                                 (frame_width, frame_height))
 
     while cap.isOpened():


### PR DESCRIPTION
Benchmarking with `only_network` was not possible due to incorrect data type of the synthetic tensor.

The `inspect_tfrecords.py` utility ignored all bounding boxes with `ymin` equal to 0. These are now correctly rendered.

It also used red color for all bounding boxes which sometimes made it difficult to distinguish different object classes if they were clustered. It now behaves identically to inference of `keras.inspector` module and uses different color for each class.

Video exported using the `keras.inspector` module now dynamically sets the frame rate of output file equal to the input file.