### PR TITLE
Fix README for fine-tuning and tutorial typo

### DIFF
--- a/efficientnetv2/README.md
+++ b/efficientnetv2/README.md
@@ -82,7 +82,7 @@ You can directly use this code to build a model like this:
 
     mode = tf.keras.models.Sequential([
         tf.keras.layers.InputLayer(input_shape=[224, 224, 3]),
-        effnetv2_model.get_model('efficientnetv2-b0', include_top=False, pretrained=True),
+        effnetv2_model.get_model('efficientnetv2-b0', include_top=False),
         tf.keras.layers.Dropout(rate=0.2),
         tf.keras.layers.Dense(4, activation='softmax'),
     ])

--- a/efficientnetv2/tutorial.ipynb
+++ b/efficientnetv2/tutorial.ipynb
@@ -181,7 +181,7 @@
         "pred = tf.keras.layers.Softmax()(logits)\n",
         "idx = tf.argsort(logits[0])[::-1][:5].numpy()\n",
         "import ast\n",
-        "classes = ast.literal_eval(open(labels_file, \"r\").read())\n",
+        "classes = ast.literal_eval(open(labels_map, \"r\").read())\n",
         "for i, id in enumerate(idx):\n",
         "  print(f'top {i+1} ({pred[0][id]*100:.1f}%):  {classes[id]} ')\n",
         "from IPython import display\n",


### PR DESCRIPTION
Fixes for EfficientNetv2 documentation.

- README snippet for fine tuning references `pretrained` param in `effnetv2_model.get_model`, but that param does not exist anymore.
- `tutorial.ipynb` references a non-existant variable `labels_file` instead of `labels_map`