### PR TITLE
Parameter count for EfficientDet lite models

### DIFF
--- a/efficientdet/README.md
+++ b/efficientdet/README.md
@@ -113,12 +113,12 @@ We have also provided a list of mobile-size lite models:
 
 |       Model    |   mAP (float) | Quantized mAP (int8) | Prameters | Mobile latency |
 | ------ | :------: | :------:  | :------: | :------:  |
-| EfficientDet-lite0,  [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite0.tgz)  |  26.41 | 26.10 | 4.3M  |  36ms |
-| EfficientDet-lite1,  [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite1.tgz)  |  31.50 | 31.12 |  5.8M |  49ms |
-| EfficientDet-lite2,  [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite2.tgz)  |  35.06 | 34.69 |  7.2M | 69ms |
-| EfficientDet-lite3,  [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite3.tgz)  |  38.77 | 38.42 |  11M  | 116ms |
-| EfficientDet-lite3x, [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite3x.tgz) |  42.64 | 41.87 |  12M  | 208ms  |
-| EfficientDet-lite4,  [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite4.tgz)  |  43.18 | 42.83 |   20M | 260ms  |
+| EfficientDet-lite0,  [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite0.tgz)  |  26.41 | 26.10 | 3.2M  |  36ms |
+| EfficientDet-lite1,  [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite1.tgz)  |  31.50 | 31.12 |  4.2M |  49ms |
+| EfficientDet-lite2,  [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite2.tgz)  |  35.06 | 34.69 |  5.3M | 69ms |
+| EfficientDet-lite3,  [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite3.tgz)  |  38.77 | 38.42 |  8.4M  | 116ms |
+| EfficientDet-lite3x, [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite3x.tgz) |  42.64 | 41.87 |  9.3M  | 208ms  |
+| EfficientDet-lite4,  [ckpt](https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco/efficientdet-lite4.tgz)  |  43.18 | 42.83 |   15.1M | 260ms  |
 
 
 ## 3. Export SavedModel, frozen graph, tensort models, or tflite.


### PR DESCRIPTION
I think the `Prameters` count for `EfficientDet-lite` models are not correct:
```py
# cd automl/efficientdet
import hparams_config
import inference
from tf2 import efficientdet_keras

config = hparams_config.get_efficientdet_config('efficientdet-lite0')
model = efficientdet_keras.EfficientDetNet(config=config)
# model = efficientdet_keras.EfficientDetModel(config=config)
model.build((None, config.image_size, config.image_size, 3))
model.summary()
```
Summary results:

| Model               | Total params | Trainable params |
| ------------------- | ------------ | ---------------- |
| efficientdet-lite0  | 3,290,606    | 3,243,470        |
| efficientdet-lite1  | 4,311,390    | 4,248,318        |
| efficientdet-lite2  | 5,324,894    | 5,252,334        |
| efficientdet-lite3  | 8,455,054    | 8,350,862        |
| efficientdet-lite3x | 9,392,574    | 9,280,862        |
| efficientdet-lite4  | 15,286,398   | 15,130,894       |