### PR TITLE
fix pretrained ckpt of efficientnet-l2

### DIFF
--- a/efficientnetv2/effnetv2_model.py
+++ b/efficientnetv2/effnetv2_model.py
@@ -781,8 +781,11 @@ def get_model(model_name,
       'efficientnet-b8': {
           'imagenet': v1url + 'efficientnet-b8.tar.gz',
       },
-      'efficientnet-l2': {
+      'efficientnet-l2_475': {
           'jft': v1jfturl + 'noisy_student_efficientnet-l2_475.tar.gz',
+      },
+      'efficientnet-l2': {
+          'jft': v1jfturl + 'noisy_student_efficientnet-l2.tar.gz',
       },
   }
 


### PR DESCRIPTION
When I use efficientnet-l2 model, it gets the pretrained ckpt of l2_475 and error occurs.
So, I fixed pretarained ckpt of l2 and l2_475.