### PR TITLE
efficientdet: update requirements.txt

### DIFF
--- a/efficientdet/requirements.txt
+++ b/efficientdet/requirements.txt
@@ -1,11 +1,11 @@
 lxml>=4.6.1
 absl-py>=0.10.0
 matplotlib>=3.0.3
-numpy>=1.19.4
+numpy>=1.19.4,<1.24.0
 Pillow>=9.5.0
 PyYAML>=5.1
 six>=1.15.0
-tensorflow>=2.10.0
+tensorflow>=2.10.0,<2.16.0
 tensorflow-addons>=0.18.0
 tensorflow-hub>=0.11
 neural-structured-learning>=1.3.1


### PR DESCRIPTION
This patch modifies the requirements file to only install TensorFlow versions older than 2.16.0, since some breaking changes made it incompatible with the efficientdet repository (like the removal of the Estimator API). It also tightens the dependency on numpy, since version 1.24.0 removed some deprecated type aliases used by cocoapi, like `np.float`.